### PR TITLE
[start]top_search

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,7 +1,21 @@
 class Public::HomesController < ApplicationController
     
     def top
+      
+    # 新着投稿の表示
       @new_posts = Post.order(create_at: :desc).limit(8)
+      
+    # 表示食材タグ名の表示
+      @display_foods = Tag.where(display_food: true)
+      
+    # 注目食材（管理者側）で設定したタグに関連する投稿の表示
+     #設定したタグの取得 
+      @pickup_foods = Tag.where(pickup_food: true)
+     #タグに関連づく投稿の取得  
+      @pickup_foods.each do |pickup_food|
+        @pickup_posts = pickup_food.posts.all
+      end
+      
     end
     
 end

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -1,17 +1,27 @@
 class Public::PostsController < ApplicationController
 
   def index
-    # 表示されたタグをクリックした場合の表示 未完成
+    
+    # 表示されたタグをクリックした場合の一覧表示 
     if params[:tag_id]
       @tag = Tag.find(params[:tag_id])
-      @post = @tag.posts.all
+      @posts = @tag.posts.all
 
-    # カテゴリーで検索した場合の表示　未完成
+    # カテゴリーで検索した場合の一覧表示
     elsif params[:category_id]
       @category = Category.find(params[:category_id])
       @posts = @category.posts.all
+    
+    #料理名で検索した場合の一覧表示
+    elsif params[:search_cooking_name]
+      @posts = Post.search(params[:search_cooking_name])
 
-    # ヘッダーの「投稿一覧」をクリックした場合の表示
+　　#食材名で検索した場合の一覧表示
+    elsif params[:search_food]
+      @tag = Tag.search_tag(params[:search_food])
+      @posts = @tag.posts.all
+      
+    # ヘッダーの「投稿一覧」をクリックした場合の表示（全投稿の表示）
     else
       @posts = Post.all
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -22,7 +22,7 @@ class Post < ApplicationRecord
 
     #調理時間15分以下の場合
     else
-     self.difficulty = 1
+      self.difficulty = 1
     end
   end
 
@@ -46,12 +46,12 @@ class Post < ApplicationRecord
   end
 
   def display_difficulty
-    if self.difficulty = 3
-      return "★★★(調理に30分以上)"
-    elsif self.difficulty = 2
-      return "★★☆(調理に15~30分)"
-    else
-      return "★☆☆(調理に15分未満)"
+    if self.difficulty == 3
+      "★★★(調理に30分以上)"
+    elsif self.difficulty == 2
+      "★★☆(調理に15~30分)"
+    elsif self.difficulty == 1
+      "★☆☆(調理に15分未満)"
     end
   end
 
@@ -59,4 +59,7 @@ class Post < ApplicationRecord
     favorites.where(user_id: user.id).exists?
   end
 
+  def self.search(search_cooking_name)
+    Post.where(["cooking_name LIKE ?", "%#{search_cooking_name}%"])
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
-  has_many :tag_maps, dependent: :destroy
+  has_many :tagmaps, dependent: :destroy
   has_many :posts, through: :tagmaps
 # 管理者側のカスタマイズ設定で注目食材か表示食材のどちらの登録か判断するために使用するカラム
   attr_accessor :selected_food

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,15 @@
       </li>
     <% elsif admin_signed_in? %>
       <li>
+        <%= link_to "カテゴリー", admin_categories_path %>
+      </li>
+      <li>
+        <%= link_to "オモさ", admin_tastes_path %>
+      </li>
+      <li>
+        <%= link_to "トップページ設定", admin_tags_path %>
+      </li>
+      <li>
         <%= link_to "ログアウト", destroy_admin_session_path, method: :delete %>
       </li>
     <% else %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,18 +1,42 @@
 <h2>topページ</h2>
 
+<!--管理者側で表示食材タグで設定したタグ名を表示-->
+<% @display_foods.each do |display_food| %>
+ <%= link_to posts_path(tag_id: display_food) do %>
+  <%= display_food.tag_name %>
+ <% end %>
+<% end %>
+
 <h4>新着投稿</h4>
+<%= render 'public/posts/top_index', posts: @new_posts %>
 
-<div class="card_group">
-  <% @new_posts.each do |new_post| %>
-    <div class="card">
-      <%= link_to post_path(new_post) do %>
-        <%= attachment_image_tag new_post, :image, size:'250x200' %></br>
-        <%= new_post.cooking_name %>
-        <%= new_post.display_difficulty%>
-      <% end %>
-    </div>
-  <% end %>
-</div>
-
+<!--検索機能-->
 <h4>検索</h4>
 
+<p>料理名で探す</p>
+<%= form_with url: posts_path, method: :get, local: true do |f| %>
+  <%= f.text_field :search_cooking_name %>
+  <%= f.submit "検索" %>
+<% end %>
+
+<p>食材名で探す</p>
+<%= form_with url: posts_path, method: :get, local: true do |f| %>
+  <%= f.text_field :search_food %>
+  <%= f.submit "検索" %>
+<% end %>
+
+
+
+
+<!--管理者側で注目食材に登録した食材に関連する投稿の表示-->
+<h4>注目食材の投稿</h4>
+
+<!--注目食材に登録しているタグ名の表示-->
+<% @pickup_foods.each do |pickup_food| %>
+ <%= link_to posts_path(tag_id: pickup_food) do %>
+  <%= pickup_food.tag_name %>
+ <% end %>
+<% end %>
+
+<!--注目食材を使用した投稿一覧-->
+<%= render 'public/posts/top_index', posts: @pickup_posts %>

--- a/app/views/public/posts/_top_index.html.erb
+++ b/app/views/public/posts/_top_index.html.erb
@@ -4,7 +4,7 @@
       <%= link_to post_path(post) do %>
         <%= attachment_image_tag post, :image, size:'250x200' %></br>
         <%= post.cooking_name %>
-        <%= post.display_difficulty %>
+        <%= post.display_difficulty%>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
トップ画面の編集
【管理者側で設定した表示食材を表示】
クリックしたタグに関連する投稿一覧を表示

【管理者側で設定した注目食材の投稿を表示】

【検索窓を設置　①料理名　②食材】
①入力された料理名を含む投稿を一覧表示
②入力された食材のタグを探し、関連する投稿を一覧表示

【その他】
・全て★★★で表示されていたエラーを修正