### PR TITLE
[fix]top&show_url

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -184,6 +184,10 @@ h3 {
   line-height: 2.5;
 }
 
+.content__url {
+  word-wrap: break-word;
+}
+
 .content__btn {
   grid-row: 2 / 3;
   grid-column: 3/ 4;

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,21 +1,25 @@
 class Public::HomesController < ApplicationController
-    
+
   def top
-    
+
     # 新着投稿の表示
     @new_posts = Post.order("posts.created_at DESC").limit(8)
 
     # 表示食材タグ名の表示
     @display_foods = Tag.where(display_food: true)
-    
+
     # 注目食材（管理者側）で設定したタグに関連する投稿の表示
     # 設定したタグの取得
     @pickup_foods = Tag.where(pickup_food: true)
     # タグに関連づく投稿の取得
+    @posts = []
     @pickup_foods.each do |pickup_food|
       @pickup_posts = pickup_food.posts.all
+      @posts += @pickup_posts
     end
+    # 複数タグで該当する投稿は一度だけ表示する
+    @posts = @posts.uniq
 
   end
-    
+
 end

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -47,5 +47,5 @@
   </div>
   
   <!--注目食材を使用した投稿一覧-->
-  <%= render 'public/posts/top_index', posts: @pickup_posts %>
+  <%= render 'public/posts/top_index', posts: @posts %>
 </div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -26,9 +26,11 @@
     
       <% if @post.url.present? %>
         参考レシピURL：
-        <%= link_to @post.url do %>
-          <%= @post.url %>
-        <% end %>
+        <div class="content__url">
+          <%= link_to @post.url do %>
+            <%= @post.url %>
+          <% end %>
+        </div>
       <% end %>
     </div>
     <div class="content__btn">


### PR DESCRIPTION
レイアウト修正
・トップページの注目食材の投稿表示部分が１つのタグの投稿しか表示できていなかったエラーを修正
・投稿詳細画面の参考レシピURLを画面幅に応じて改行するように修正