### PR TITLE
Develop

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -184,6 +184,10 @@ h3 {
   line-height: 2.5;
 }
 
+.content__url {
+  word-wrap: break-word;
+}
+
 .content__btn {
   grid-row: 2 / 3;
   grid-column: 3/ 4;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -321,6 +321,15 @@ footer p {
 }
 
 @media screen and (max-width:425px) {
+  
+  .btn1 {
+    z-index: 0;
+  }
+  
+  .btn2 {
+    z-index: 0;
+  }
+  
   header {
     height: 50px;
     width: 100%;
@@ -338,6 +347,7 @@ footer p {
   }
   
   .header__nav ul {
+    z-index: 1;
     position: absolute;
     left: -500px;
     height: 70%;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -278,7 +278,7 @@ footer p {
   
   .header__nav ul {
     display: block;
-    font-size: 10px;
+    font-size: 13px;
     line-height: 50px;
     text-align: center;
     margin: 5px 0;
@@ -344,6 +344,9 @@ footer p {
     position: absolute;
     top: 20px;
     left: 20px;
+    color: #7b7878;
+    font-weight: bold;
+    font-family: fantasy;
   }
   
   .header__nav ul {

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,21 +1,25 @@
 class Public::HomesController < ApplicationController
-    
+
   def top
-    
+
     # 新着投稿の表示
     @new_posts = Post.order("posts.created_at DESC").limit(8)
 
     # 表示食材タグ名の表示
     @display_foods = Tag.where(display_food: true)
-    
+
     # 注目食材（管理者側）で設定したタグに関連する投稿の表示
     # 設定したタグの取得
     @pickup_foods = Tag.where(pickup_food: true)
     # タグに関連づく投稿の取得
+    @posts = []
     @pickup_foods.each do |pickup_food|
       @pickup_posts = pickup_food.posts.all
+      @posts += @pickup_posts
     end
+    # 複数タグで該当する投稿は一度だけ表示する
+    @posts = @posts.uniq
 
   end
-    
+
 end

--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -3,9 +3,8 @@ class Public::HomesController < ApplicationController
   def top
     
     # 新着投稿の表示
-    @new_posts = Post.order("posts.created_at DESC")
-    
-    
+    @new_posts = Post.order("posts.created_at DESC").limit(8)
+
     # 表示食材タグ名の表示
     @display_foods = Tag.where(display_food: true)
     
@@ -16,7 +15,7 @@ class Public::HomesController < ApplicationController
     @pickup_foods.each do |pickup_food|
       @pickup_posts = pickup_food.posts.all
     end
-    
+
   end
     
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,6 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <link href="https://fonts.googleapis.com/css?family=M+PLUS+1p" rel="stylesheet">
-    <!--<link href="https://fonts.googleapis.com/earlyaccess/nicomoji.css" rel="stylesheet">-->
   </head>
 
   <body>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -47,5 +47,5 @@
   </div>
   
   <!--注目食材を使用した投稿一覧-->
-  <%= render 'public/posts/top_index', posts: @pickup_posts %>
+  <%= render 'public/posts/top_index', posts: @posts %>
 </div>

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -26,9 +26,11 @@
     
       <% if @post.url.present? %>
         参考レシピURL：
-        <%= link_to @post.url do %>
-          <%= @post.url %>
-        <% end %>
+        <div class="content__url">
+          <%= link_to @post.url do %>
+            <%= @post.url %>
+          <% end %>
+        </div>
       <% end %>
     </div>
     <div class="content__btn">

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -33,6 +33,7 @@
     </div>
     <div class="content__btn">
       <% if current_user == nil %>
+        <!--お気に入り登録できず、新規会員登録画面へ遷移する-->
         <%= link_to "お気に入り登録", new_user_registration_path, class: " btn btn-2" %>
       <% elsif current_user.id == @post.user_id %>
         <%= link_to "編集する", edit_post_path(@post), class: "btn btn-2" %>


### PR DESCRIPTION
レイアウト修正
・トップページの注目食材に関連する投稿が、１つのタグに日もづく投稿しか表示できていなかったエラーを修正
・投稿詳細ページで参考レシピURLの文字列が画面幅によって折り返すように修正